### PR TITLE
Add a default range of 500 commits

### DIFF
--- a/Sources/git-changelog/GitChangelog.swift
+++ b/Sources/git-changelog/GitChangelog.swift
@@ -48,96 +48,119 @@ public final class GitChangelog {
             switch subcommand {
             case "--version":
                 print("v\(VERSION)")
+                
+            case "--from", "-f":
+                var toRef = "HEAD"
+                if self.arguments.count > 3 {
+                    let to = self.arguments[3]
+                    switch to {
+                    case "--to", "-t":
+                        toRef = self.arguments[4]
+                    default:
+                        toRef = "HEAD"
+                    }
+                }
+                let fromRef = self.arguments[2]
+                try self.fetchChangelog(from: fromRef, to: toRef)
+            
+            case "--max", "-m":
+                let count = Int(self.arguments[2])
+                try self.fetchChangelog(withMax: count)
+                
             default:
                 print("Unrecognized commande line arguments")
             }
         } else {
-            var changelog: Changelog = Changelog()
-            var currentReleaseID: Changelog.ReleaseID?
+            try self.fetchChangelog(withMax: 500)
+        }
+    }
+    
+    func fetchChangelog(from fromRef: String? = nil, to toRef: String? = nil, withMax maxCount: Int? = nil) throws {
+        var changelog: Changelog = Changelog()
+        var currentReleaseID: Changelog.ReleaseID?
 
-            let commits = try! self.git.commits()
-            try! commits.forEach { commit in
-                // this commit has version bump
+        let commits = try self.git.commits(fromRef: fromRef, toRef: toRef, maxCount: maxCount)
+        try! commits.forEach { commit in
+            // this commit has version bump
 
-                let changelogBody = commit.body.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: "[changelog]").dropFirst().joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+            let changelogBody = commit.body.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: "[changelog]").dropFirst().joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
 
-                let pattern = #"(added|changed|deprecated|removed|fixed|security|release):\w?(.*)"#
-                let regex = try NSRegularExpression(pattern: pattern, options: [])
+            let pattern = #"(added|changed|deprecated|removed|fixed|security|release):\w?(.*)"#
+            let regex = try NSRegularExpression(pattern: pattern, options: [])
 
-                let nsrange = NSRange(changelogBody.startIndex..<changelogBody.endIndex,
-                in: changelogBody)
-                regex.enumerateMatches(in: changelogBody, options: [], range: nsrange) {
-                     (match, _, stop) in
+            let nsrange = NSRange(changelogBody.startIndex..<changelogBody.endIndex,
+            in: changelogBody)
+            regex.enumerateMatches(in: changelogBody, options: [], range: nsrange) {
+                 (match, _, stop) in
 
-                    guard let match = match else { return }
+                guard let match = match else { return }
 
-                    if match.numberOfRanges == 3 {
-                        guard let firstCaptureRange = Range(match.range(at: 1),
-                        in: changelogBody),
-                        let secondCaptureRange = Range(match.range(at: 2),
-                                                       in: changelogBody) else {
-                                                        return
-                        }
+                if match.numberOfRanges == 3 {
+                    guard let firstCaptureRange = Range(match.range(at: 1),
+                    in: changelogBody),
+                    let secondCaptureRange = Range(match.range(at: 2),
+                                                   in: changelogBody) else {
+                                                    return
+                    }
 
-                        let category = changelogBody[firstCaptureRange].trimmingCharacters(in: .whitespacesAndNewlines)
-                        let message = changelogBody[secondCaptureRange].trimmingCharacters(in: .whitespacesAndNewlines)
+                    let category = changelogBody[firstCaptureRange].trimmingCharacters(in: .whitespacesAndNewlines)
+                    let message = changelogBody[secondCaptureRange].trimmingCharacters(in: .whitespacesAndNewlines)
 
-                        switch category {
-                        case "release":
-                            currentReleaseID = message
-                            changelog.releases[currentReleaseID!] = Changelog.Release(date: commit.date, id: currentReleaseID!, categorizedEntries: [:])
-                        default:
-                            if let releaseID = currentReleaseID {
-                                if let _ = changelog.releases[releaseID]!.categorizedEntries[category] {
-                                    changelog.releases[releaseID]!.categorizedEntries[category]!.append(message)
-                                } else {
-                                    changelog.releases[releaseID]!.categorizedEntries[category] = [message]
-                                }
+                    switch category {
+                    case "release":
+                        currentReleaseID = message
+                        changelog.releases[currentReleaseID!] = Changelog.Release(date: commit.date, id: currentReleaseID!, categorizedEntries: [:])
+                    default:
+                        if let releaseID = currentReleaseID {
+                            if let _ = changelog.releases[releaseID]!.categorizedEntries[category] {
+                                changelog.releases[releaseID]!.categorizedEntries[category]!.append(message)
                             } else {
-                                if let _ = changelog.unreleased.categorizedEntries[category] {
-                                    changelog.unreleased.categorizedEntries[category]!.append(message)
-                                } else {
-                                    changelog.unreleased.categorizedEntries[category] = [message]
-                                }
+                                changelog.releases[releaseID]!.categorizedEntries[category] = [message]
+                            }
+                        } else {
+                            if let _ = changelog.unreleased.categorizedEntries[category] {
+                                changelog.unreleased.categorizedEntries[category]!.append(message)
+                            } else {
+                                changelog.unreleased.categorizedEntries[category] = [message]
                             }
                         }
                     }
                 }
             }
+        }
 
-            var markdownChanglog = ""
+        var markdownChanglog = ""
 
-            markdownChanglog += """
-            # Changelog
+        markdownChanglog += """
+        # Changelog
 
-            All notable changes to this project will be documented in this file.
+        All notable changes to this project will be documented in this file.
 
-            The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-            and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-            """
+        The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+        and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+        """
 
-            markdownChanglog += "\n\n## Unreleased - now\n"
+        markdownChanglog += "\n\n## Unreleased - now\n"
 
-            changelog.unreleased.categorizedEntries.forEach { (category, entries) in
+        changelog.unreleased.categorizedEntries.forEach { (category, entries) in
+            markdownChanglog += "\n### \(category.capitalized)\n"
+            entries.forEach { (entry) in
+                markdownChanglog += "- \(entry)\n"
+            }
+        }
+
+        changelog.releases.forEach { (releaseID, release) in
+            markdownChanglog += "\n\n## \(releaseID) - \(self.dateFormatter.string(from: release.date))\n"
+            release.categorizedEntries.forEach { (category, entries) in
                 markdownChanglog += "\n### \(category.capitalized)\n"
                 entries.forEach { (entry) in
                     markdownChanglog += "- \(entry)\n"
                 }
             }
-
-            changelog.releases.forEach { (releaseID, release) in
-                markdownChanglog += "\n\n## \(releaseID) - \(self.dateFormatter.string(from: release.date))\n"
-                release.categorizedEntries.forEach { (category, entries) in
-                    markdownChanglog += "\n### \(category.capitalized)\n"
-                    entries.forEach { (entry) in
-                        markdownChanglog += "- \(entry)\n"
-                    }
-                }
-            }
-
-            print(markdownChanglog)
-
         }
+
+        print(markdownChanglog)
+
     }
 }
 


### PR DESCRIPTION
This adds a default max coount when fetching commits to 500. You can
specifiy a custom amount by passing --max/-m or you can specifiy the
range to generate from via the --from/-f command. This will allow you to
generate a changelog from a tag to the HEAD or to a specific via the
--to/-t subcommand.

[changelog]
added: Implemented a way to fetch commits from a tag [#3](https://github.com/uptech/git-changelog/issues/3)
added: Added support for fetching between tag [#6](https://github.com/uptech/git-changelog/issues/3)
added: Implemented a way to limit the number of commits fetched
fixed: Large commit repositories would take forever to load, so
specifying a default limit of 500 was still fast enough.

ps-id: 7C1F044D-CAC0-40D8-9527-79A1273ECC3C